### PR TITLE
Clear the Printer status box on the Printing Example activity resume.

### DIFF
--- a/PrintingExample/src/main/java/com/aevi/example/print/PrintingActivity.java
+++ b/PrintingExample/src/main/java/com/aevi/example/print/PrintingActivity.java
@@ -112,7 +112,13 @@ public class PrintingActivity extends AppCompatActivity {
         super.onResume();
         printPayloadData = new PrintPayloadData(this);
         enableButtons(false);
+        clearPrinterStatus();
         setupPrintDrivers();
+    }
+
+    private void clearPrinterStatus() {
+        latestPrinterStatus.clear();
+        printerStatusDisplay.setText("");
     }
 
     private void setupPrintDrivers() {
@@ -298,15 +304,11 @@ public class PrintingActivity extends AppCompatActivity {
     private void displayPrintResultMessage(@NonNull PrintJob printResult) {
         if (printResult.getPrintJobState() == PrintJob.State.FAILED) {
             showToastMessage(getString(R.string.failure_toast_message, printResult.getPrintJobState(), printResult.getFailedReason()));
-            Log.d(TAG, "Got status from printer: " + printResult.getPrintJobState() + " : " + printResult.getFailedReason() + " - " + printResult
+            Log.d(TAG, "Printing result: " + printResult.getPrintJobState() + " : " + printResult.getFailedReason()  + " - " + printResult
                     .getDiagnosticMessage());
-            String diagnosticMessage = printResult.getDiagnosticMessage();
-            if (diagnosticMessage != null) {
-                Log.i(TAG, "Got status diagnostic message from printer: " + diagnosticMessage);
-            }
-        } else {
-            showToastMessage(getString(R.string.status_toast_message, printResult.getPrintJobState()));
-            Log.d(TAG, "Got status from printer: " + printResult.getPrintJobState());
+          } else {
+            showToastMessage(getString(R.string.result_toast_message, printResult.getPrintJobState()));
+            Log.d(TAG, "Printing result: " + printResult.getPrintJobState());
         }
     }
 

--- a/PrintingExample/src/main/res/values/strings.xml
+++ b/PrintingExample/src/main/res/values/strings.xml
@@ -27,8 +27,8 @@
     <string name="preview_receipt">Preview</string>
     <string name="print_receipt">Print</string>
 
-    <string name="status_toast_message">Got status from printer: %1$s</string>
-    <string name="failure_toast_message">Got status from printer: %1$s (%2$s)</string>
+    <string name="result_toast_message">Print result: %1$s</string>
+    <string name="failure_toast_message">Print result: %1$s (%2$s)</string>
 
     <string name="printing_with_code_page">Printing with code page</string>
     <string name="preview_code_page_example">Preview code page example</string>

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ if(printerManager.isPrinterServiceAvailable()) {
               @Override
               public void accept(@NonNull PrintJob printResult) throws Exception {
                   // Do something with results here
-                  Log.d(TAG, "Got status from printer: " + printResult.getPrintJobState());
+                  Log.d(TAG, "Got printing result:: " + printResult.getPrintJobState());
               }
           }, new Consumer<Throwable>() {
               @Override

--- a/documentation/source/includes/_printing.md
+++ b/documentation/source/includes/_printing.md
@@ -15,7 +15,7 @@ if(printerManager.isPrinterServiceAvailable()) {
               @Override
               public void accept(@NonNull PrintJob printResult) throws Exception {
                   // Do something with results here
-                  Log.d(TAG, "Got status from printer: " + printResult.getPrintJobState());
+                  Log.d(TAG, "Got printing result: " + printResult.getPrintJobState());
               }
           }, new Consumer<Throwable>() {
               @Override

--- a/print-api/src/main/java/com/aevi/print/model/PrintJob.java
+++ b/print-api/src/main/java/com/aevi/print/model/PrintJob.java
@@ -80,6 +80,9 @@ public class PrintJob extends SendableId {
      * @return The reason giving the cause of any failure {@link PrinterMessages}
      */
     public String getFailedReason() {
+        if (failedReason == null) {
+            return "";
+        }
         return failedReason;
     }
 


### PR DESCRIPTION
Also renamed the text displaying print job result so that is it not confused with status messages.